### PR TITLE
[chore] 젠킨스 https 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,9 +60,6 @@ aws ecr get-login-password --region "${AWS_REGION}" \
 
 docker build -t "${ECR_REPO_URI}:${IMAGE_TAG}" .
 docker push "${ECR_REPO_URI}:${IMAGE_TAG}"
-
-docker tag "${ECR_REPO_URI}:${IMAGE_TAG}" "${ECR_REPO_URI}:latest"
-docker push "${ECR_REPO_URI}:latest"
 '''
         }
       }
@@ -134,7 +131,11 @@ echo "[skip] MongoDB: using MongoDB Atlas (no in-cluster MongoDB)"
 
     stage("Deploy App (Deployment/Service/Ingress)") {
       steps {
-        sh '''#!/usr/bin/env bash
+        withCredentials([[
+          $class: 'AmazonWebServicesCredentialsBinding',
+          credentialsId: 'aws-credentials'
+        ]]) {
+          sh '''#!/usr/bin/env bash
 set -euo pipefail
 
 command -v envsubst >/dev/null 2>&1 || {
@@ -149,6 +150,7 @@ kubectl get pods -o wide
 kubectl get svc -o wide
 kubectl get ingress -o wide || true
 '''
+        }
       }
     }
 

--- a/k8s/app/ingress.yaml
+++ b/k8s/app/ingress.yaml
@@ -4,6 +4,8 @@ metadata:
   name: runrun-ingress
   namespace: default
   annotations:
+    # NOTE: This Ingress is a legacy manifest. If you deploy via `k8s/eks_deploy_alb.yml`,
+    # do not apply this file to avoid creating/updating a separate ALB configuration.
     kubernetes.io/ingress.class: "alb"
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip

--- a/k8s/eks_deploy_alb.yml
+++ b/k8s/eks_deploy_alb.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: runrun
-          image: ${ECR_REPO_URI}:latest
+          image: ${ECR_REPO_URI}:${IMAGE_TAG}
           envFrom:
             - secretRef:
                 name: runrun-env
@@ -77,16 +77,26 @@ metadata:
     kubernetes.io/ingress.class: "alb"                                 # ingressClassName 대신 안전하게 지정
     alb.ingress.kubernetes.io/scheme: internet-facing                    # internet-facing 또는 internal
     alb.ingress.kubernetes.io/target-type: ip                            # ip -> pod IP를 타깃으로 등록 (노드 대신)
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'              # HTTP 포트 설정
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'              # HTTP/HTTPS 포트 설정
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:mx-central-1:118320467932:certificate/3fddc5dc-9edd-4506-84b1-25caeda906ef"
+    alb.ingress.kubernetes.io/actions.ssl-redirect: >-
+      {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}
     alb.ingress.kubernetes.io/healthcheck-path: "/actuator/health"                      # ALB 헬스체크 경로 (서비스에 맞게 조정) 앱에서 인증 없이 200을 반환하는 헬스 엔드포인트(예: /actuator/health)를 추가 시큐리티랑 필터에추가
     alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"  #port: 80 targetPort: 8090 이므로 ALB가 Service→Pod로 보낼 때 내부적으로 올바른 포트(=8090)로 전달되도록 컨트롤러가 처리
     alb.ingress.kubernetes.io/success-codes: "200-399"
     # 필요 시 세부 설정 추가 (예: 인증, WAF, stickiness 등)
 spec:
   rules:
-    #    - host: example.yourdomain.com    # 실제 도메인으로 교체.
-    - http:
+    - host: api.runrunmatch.cloud
+      http:
         paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#152 
## 📝 작업 내용
- 
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR 요약: Jenkins 파일 HTTPS 추가

### 개요
이 PR은 RunRun 애플리케이션 배포 파이프라인에 HTTPS 지원을 추가합니다. Jenkins 파이프라인 구성을 강화하고, Kubernetes 매니페스트에 TLS/HTTPS 설정을 도입합니다.

### 주요 변경 사항

#### 1. Jenkinsfile 수정 (+6/-4)
**Deploy App 스테이지 개선:**
- AWS 크레덴셜 바인딩을 적용하여 배포 작업 보안 강화
- `envsubst` 유틸리티 존재 여부 검증 로직 추가
  - 미설치 시 `gettext-base` 패키지 설치 가이드 제공
- 환경 변수 치환(`${ECR_REPO_URI}`, `${IMAGE_TAG}`)을 통해 동적 이미지 태그 적용
- `kubectl rollout status` 명령으로 배포 완료 대기 (타임아웃 300초)
- Pod, Service, Ingress 상태 확인 명령 통합
- ECR 최신 태그 관련 Docker push 명령 2개 제거

#### 2. k8s/app/ingress.yaml 수정 (+2/-0)
- 메타데이터 주석에 레거시 매니페스트임을 명시
- `k8s/eks_deploy_alb.yml`을 통한 배포 시 이 파일을 적용하지 않을 것을 권고
- 함수 동작 변경 없음 (문서화 목적)

#### 3. k8s/eks_deploy_alb.yml 수정 (+14/-4)
**HTTPS 및 TLS 설정 추가:**
- 컨테이너 이미지 태그를 `latest`에서 `${IMAGE_TAG}` 환경 변수로 변경
- ALB 리스너 포트 확장: HTTP(80)만 지원 → HTTP(80) + HTTPS(443) 병행 지원
- ACM 인증서 ARN 추가 (mx-central-1 리전)
- HTTP → HTTPS 자동 리다이렉트 정책 설정 (상태코드 301)
- Ingress 규칙에 `api.runrunmatch.cloud` 호스트 명시
- SSL 리다이렉트 서비스(`ssl-redirect`) 경로 추가
- 기존 애플리케이션 서비스(`runrun-svc`)로의 라우팅 경로 유지

### 코드 품질 및 준수 사항

#### 장점
- **배포 안정성 강화**: envsubst 유틸리티 사전 확인으로 배포 실패 방지
- **보안 개선**: HTTPS 강제 적용 및 SSL 리다이렉트를 통한 암호화 통신 보장
- **명확한 의도 표현**: Ingress 주석으로 레거시 파일임을 명시하여 운영 오류 방지
- **동적 배포**: 환경 변수 기반 이미지 태그로 빌드 번호 추적 가능
- **배포 검증**: rollout status 및 리소스 상태 확인으로 배포 성공 여부 명확화

#### 검토 권고사항
- **envsubst 설치 상태 확인**: 배포 환경에서 `gettext-base` 패키지 사전 설치 필요 (또는 다른 환경 변수 치환 도구 검토)
- **기존 ALB와의 충돌**: 레거시 ingress.yaml이 여전히 클러스터에 적용되어 있다면 중복 ALB 생성 위험 → 레거시 파일 제거 필요
- **트래픽 중단 최소화**: SSL 리다이렉트 적용 시 클라이언트 캐시 고려 (필요시 301 리다이렉트 대신 302 임시 리다이렉트 검토)
- **TLS 인증서 갱신**: ACM 인증서 만료일 모니터링 및 자동 갱신 정책 확인
- **헬스체크 엔드포인트**: `/actuator/health` 엔드포인트가 인증 없이 200을 반환하는지 확인 필요

### 관련 이슈
#152

<!-- end of auto-generated comment: release notes by coderabbit.ai -->