### PR TITLE
[chore] service ingress 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     booleanParam(
       name: 'SETUP_MONITORING',
       defaultValue: false,
-      description: 'Install/upgrade kube-prometheus-stack + RunRun monitoring manifests (requires Jenkins credential: slack-webhook-url).'
+      description: 'Install/upgrade kube-prometheus-stack + RunRun monitoring manifests (assumes alertmanager-slack Secret already exists).'
     )
   }
 
@@ -85,21 +85,21 @@ kubectl get nodes
         expression { return params.SETUP_MONITORING }
       }
       steps {
-        withCredentials([
-          [
-            $class: 'AmazonWebServicesCredentialsBinding',
-            credentialsId: 'aws-credentials'
-          ],
-          string(credentialsId: 'slack-webhook-url', variable: 'SLACK_WEBHOOK_URL')
-        ]) {
+        withCredentials([[
+          $class: 'AmazonWebServicesCredentialsBinding',
+          credentialsId: 'aws-credentials'
+        ]]) {
           sh '''#!/usr/bin/env bash
 set -euo pipefail
 
 kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
 
-kubectl -n monitoring create secret generic alertmanager-slack \
-  --from-literal=SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL}" \
-  --dry-run=client -o yaml | kubectl apply -f -
+if ! kubectl -n monitoring get secret alertmanager-slack >/dev/null 2>&1; then
+  echo "[skip] alertmanager-slack secret not found in namespace monitoring"
+  echo "Create it once with:"
+  echo "  kubectl -n monitoring create secret generic alertmanager-slack --from-literal=SLACK_WEBHOOK_URL='https://hooks.slack.com/services/XXX/YYY/ZZZ'"
+  exit 0
+fi
 
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update

--- a/k8s/eks_deploy_alb.yml
+++ b/k8s/eks_deploy_alb.yml
@@ -1,120 +1,118 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: runrun
-  labels:
-    app: runrun
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: runrun
-  template:
-    metadata:
-      labels:
+    name: runrun
+    labels:
         app: runrun
-    spec:
-      containers:
-        - name: runrun
-          image: ${ECR_REPO_URI}:${IMAGE_TAG}
-          envFrom:
-            - secretRef:
-                name: runrun-env
-          env:
-            - name: SPRING_PROFILES_ACTIVE
-              value: "prod"
-            - name: SPRING_DATASOURCE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: runrun-db
-                  key: url
-            - name: SPRING_DATASOURCE_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: runrun-db
-                  key: username
-            - name: SPRING_DATASOURCE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: runrun-db
-                  key: password
-          ports:
-            - containerPort: 8080
-          imagePullPolicy: Always
-          resources:
-            limits:
-              memory: "512Mi"
-              cpu: "500m"
-            requests:
-              memory: "256Mi"
-              cpu: "250m"
+spec:
+    replicas: 2
+    selector:
+        matchLabels:
+            app: runrun
+    template:
+        metadata:
+            labels:
+                app: runrun
+        spec:
+            containers:
+                - name: runrun
+                  image: ${ECR_REPO_URI}:${IMAGE_TAG}
+                  envFrom:
+                      - secretRef:
+                            name: runrun-env
+                  env:
+                      - name: SPRING_PROFILES_ACTIVE
+                        value: 'prod'
+                      - name: SPRING_DATASOURCE_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: runrun-db
+                                key: url
+                      - name: SPRING_DATASOURCE_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: runrun-db
+                                key: username
+                      - name: SPRING_DATASOURCE_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: runrun-db
+                                key: password
+                  ports:
+                      - containerPort: 8080
+                  imagePullPolicy: Always
+                  resources:
+                      limits:
+                          memory: '512Mi'
+                          cpu: '500m'
+                      requests:
+                          memory: '256Mi'
+                          cpu: '250m'
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: runrun-svc
-  labels:
-    app: runrun
+    name: runrun-svc
+    namespace: default
+    labels:
+        app: runrun
 spec:
-  selector:
-    app: runrun
-  ports:
-    - name: http
-      protocol: TCP
-      port: 80            # ALB가 접근할 포트
-      targetPort: 8080    # 컨테이너 내부 포트
-  type: ClusterIP       # ALB controller (Ingress) 사용 시 ClusterIP 권장 (pod IP 직접 target 등록)
+    selector:
+        app: runrun
+    ports:
+        - name: http
+          protocol: TCP
+          port: 80
+          targetPort: 8080
+    type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: ssl-redirect
+    namespace: default
+spec:
+    type: ClusterIP
+    ports:
+        - name: use-annotation
+          port: 443
+          targetPort: 443
 
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: runrun-ingress
-  namespace: default
-  annotations:
-    # ALB 컨트롤러 동작 관련 필수/권장 어노테이션
-    kubernetes.io/ingress.class: "alb"                                 # ingressClassName 대신 안전하게 지정
-    alb.ingress.kubernetes.io/scheme: internet-facing                    # internet-facing 또는 internal
-    alb.ingress.kubernetes.io/target-type: ip                            # ip -> pod IP를 타깃으로 등록 (노드 대신)
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'              # HTTP/HTTPS 포트 설정
-    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:mx-central-1:118320467932:certificate/3fddc5dc-9edd-4506-84b1-25caeda906ef"
-    alb.ingress.kubernetes.io/actions.ssl-redirect: >-
-      {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}
-    alb.ingress.kubernetes.io/healthcheck-path: "/actuator/health"                      # ALB 헬스체크 경로 (서비스에 맞게 조정) 앱에서 인증 없이 200을 반환하는 헬스 엔드포인트(예: /actuator/health)를 추가 시큐리티랑 필터에추가
-    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"  #port: 80 targetPort: 8090 이므로 ALB가 Service→Pod로 보낼 때 내부적으로 올바른 포트(=8090)로 전달되도록 컨트롤러가 처리
-    alb.ingress.kubernetes.io/success-codes: "200-399"
-    # 필요 시 세부 설정 추가 (예: 인증, WAF, stickiness 등)
+    name: runrun-ingress
+    namespace: default
+    annotations:
+        kubernetes.io/ingress.class: 'alb'
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+        alb.ingress.kubernetes.io/certificate-arn: 'arn:aws:acm:mx-central-1:118320467932:certificate/3fddc5dc-9edd-4506-84b1-25caeda906ef'
+        alb.ingress.kubernetes.io/actions.ssl-redirect: >-
+            {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}
+        alb.ingress.kubernetes.io/healthcheck-path: '/actuator/health'
+        alb.ingress.kubernetes.io/healthcheck-port: 'traffic-port'
+        alb.ingress.kubernetes.io/success-codes: '200-399'
 spec:
-  rules:
-    - host: api.runrunmatch.cloud
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: ssl-redirect
-                port:
-                  name: use-annotation
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: runrun-svc
-                port:
-                  number: 80
-#  defaultBackend:  #ALB DNS 이름(예: a12345-abcdef.ap-northeast-2.elb.amazonaws.com)으로 바로 접속
-#    service:
-#      name: spring-boot-service
-#      port:
-#        number: 80
-
-
-
-#  Ingress 이름이 같으면
-#  -> 기존 ALB를 그대로 사용하고
-#  ->변경된 설정만 반영(update)됨
-#
-#  Ingress 이름이 달라지면
-#  -> 새로운 ALB가 생성됨
+    rules:
+        - host: api.runrunmatch.cloud
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: ssl-redirect
+                            port:
+                                name: use-annotation
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: runrun-svc
+                            port:
+                                number: 80


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#157 
## 📝 작업 내용
- 
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR 요약

## 개요
이 PR은 관련 이슈 #157을 해결하기 위해 Jenkins CI/CD 파이프라인과 Kubernetes 배포 매니페스트를 새로 추가하는 인프라 구성 작업입니다.

## 주요 변경사항

### 1. Jenkinsfile 추가 (179줄)
**Jenkins 파이프라인 새규 구성:**
- **모니터링 파라미터 개선**: `SETUP_MONITORING` 파라미터 설명을 변경하여 alertmanager-slack Secret이 사전에 존재한다고 가정하도록 명시
- **자격증 바인딩 단순화**: Setup Monitoring 단계에서 `slack-webhook-url` Jenkins 자격증 바인딩을 제거하고, AWS 자격증 바인딩만 유지
- **Secret 존재 여부 사전 확인**: 모니터링 설정 시 alertmanager-slack Secret 존재 여부를 점검한 후, 미존재 시 가이드 메시지 출력 및 종료 (기존 Secret 자동 생성 방식에서 조건부 검사 방식으로 변경)
- **파이프라인 구성**: Checkout → Gradle Build → Docker Build & Push (ECR) → kubeconfig 구성 → 모니터링 설정 → 앱 배포 → ALB 검증의 6개 단계 구성

### 2. k8s/eks_deploy_alb.yml 추가 (118줄)
**Kubernetes 배포 매니페스트 새규 구성:**

**Deployment (runrun):**
- 2개 레플리카 구성
- ECR 이미지 사용 (환경 변수로 태그 동적 지정)
- envFrom으로 runrun-env Secret 참조 및 개별 환경변수 정의 (DB 연결 정보, Spring Profile)
- 컨테이너 포트 8080, imagePullPolicy: Always
- 리소스 제한: 메모리 512Mi/CPU 500m, 요청: 메모리 256Mi/CPU 250m

**Service 1 (runrun-svc):**
- ClusterIP 타입
- 포트 80 → targetPort 8080 매핑 (HTTP 트래픽)
- 셀렉터: app: runrun

**Service 2 (ssl-redirect):**
- ClusterIP 타입 (실제 리다이렉트 로직은 Ingress annotation으로 처리)
- 포트 443 설정

**Ingress (runrun-ingress):**
- ALB Ingress Controller 활용 (alb.ingress.kubernetes.io annotation)
- 호스트: api.runrunmatch.cloud
- HTTP/HTTPS 리스닝 포트 설정 및 ACM 인증서 ARN 지정
- ALB annotation을 통한 HTTPS 리다이렉트 구성 (HTTP 301 리다이렉트)
- healthcheck 설정: /actuator/health 경로, 200-399 상태 코드 성공 판정
- 경로 라우팅: ssl-redirect 서비스와 runrun-svc 서비스로 트래픽 분산

## 기능 변경 영향

**모니터링 설정 변경의 영향:**
- 기존: Jenkins credentials에서 Slack webhook URL을 가져와 Secret 자동 생성
- 변경: alertmanager-slack Secret이 사전에 수동으로 생성되어 있다고 가정
- **영향**: Jenkins 파이프라인 실행 전에 모니터링 네임스페이스에 Secret을 미리 생성해야 함. 파이프라인에서 Secret 미존재 시 조기 종료(exit 0)되어 모니터링 설정이 스킵됨

**Kubernetes 배포 구조:**
- 신규 추가로 기존 기능에 대한 직접적인 영향 없음
- ALB 기반 진입점을 통한 HTTP/HTTPS 요청 처리 및 TLS 리다이렉트 정책 적용

## 보안 및 설정 검토 사항

✅ **AWS 자격증 관리**: withCredentials를 통한 안전한 바인딩 (Jenkinsfile 모든 AWS 필요 단계)
✅ **Secret 관리**: alertmanager-slack Secret 사전 존재 확인으로 자동 생성 리스크 제거
✅ **Kubernetes 리소스**: CPU/메모리 요청/제한 명시적 정의
✅ **인증서**: AWS ACM 인증서 ARN 명시로 HTTPS 보안 설정
⚠️ **확인 필요**: alertmanager-slack Secret 수동 생성 절차가 배포 팀에 공지/문서화되었는지 확인 필요

## 코드 컨벤션 및 일관성
- Jenkinsfile: Declarative Pipeline 형식 준수, bash strict mode(`set -euo pipefail`) 적용
- Kubernetes 매니페스트: yaml 들여쓰기 4칸 일관성, 메타데이터/스펙 구조 표준화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->