### PR TITLE
[chore] arm 주소 수정

### DIFF
--- a/k8s/eks_deploy_alb.yml
+++ b/k8s/eks_deploy_alb.yml
@@ -1,118 +1,118 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: runrun
-    labels:
-        app: runrun
+  name: runrun
+  labels:
+    app: runrun
 spec:
-    replicas: 2
-    selector:
-        matchLabels:
-            app: runrun
-    template:
-        metadata:
-            labels:
-                app: runrun
-        spec:
-            containers:
-                - name: runrun
-                  image: ${ECR_REPO_URI}:${IMAGE_TAG}
-                  envFrom:
-                      - secretRef:
-                            name: runrun-env
-                  env:
-                      - name: SPRING_PROFILES_ACTIVE
-                        value: 'prod'
-                      - name: SPRING_DATASOURCE_URL
-                        valueFrom:
-                            secretKeyRef:
-                                name: runrun-db
-                                key: url
-                      - name: SPRING_DATASOURCE_USERNAME
-                        valueFrom:
-                            secretKeyRef:
-                                name: runrun-db
-                                key: username
-                      - name: SPRING_DATASOURCE_PASSWORD
-                        valueFrom:
-                            secretKeyRef:
-                                name: runrun-db
-                                key: password
-                  ports:
-                      - containerPort: 8080
-                  imagePullPolicy: Always
-                  resources:
-                      limits:
-                          memory: '512Mi'
-                          cpu: '500m'
-                      requests:
-                          memory: '256Mi'
-                          cpu: '250m'
+  replicas: 2
+  selector:
+    matchLabels:
+      app: runrun
+  template:
+    metadata:
+      labels:
+        app: runrun
+    spec:
+      containers:
+        - name: runrun
+          image: ${ECR_REPO_URI}:${IMAGE_TAG}
+          envFrom:
+            - secretRef:
+                name: runrun-env
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: 'prod'
+            - name: SPRING_DATASOURCE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: runrun-db
+                  key: url
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: runrun-db
+                  key: username
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: runrun-db
+                  key: password
+          ports:
+            - containerPort: 8080
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: '512Mi'
+              cpu: '500m'
+            requests:
+              memory: '256Mi'
+              cpu: '250m'
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-    name: runrun-svc
-    namespace: default
-    labels:
-        app: runrun
+  name: runrun-svc
+  namespace: default
+  labels:
+    app: runrun
 spec:
-    selector:
-        app: runrun
-    ports:
-        - name: http
-          protocol: TCP
-          port: 80
-          targetPort: 8080
-    type: ClusterIP
+  selector:
+    app: runrun
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-    name: ssl-redirect
-    namespace: default
+  name: ssl-redirect
+  namespace: default
 spec:
-    type: ClusterIP
-    ports:
-        - name: use-annotation
-          port: 443
-          targetPort: 443
+  type: ClusterIP
+  ports:
+    - name: use-annotation
+      port: 443
+      targetPort: 443
 
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-    name: runrun-ingress
-    namespace: default
-    annotations:
-        kubernetes.io/ingress.class: 'alb'
-        alb.ingress.kubernetes.io/scheme: internet-facing
-        alb.ingress.kubernetes.io/target-type: ip
-        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-        alb.ingress.kubernetes.io/certificate-arn: 'arn:aws:acm:mx-central-1:118320467932:certificate/3fddc5dc-9edd-4506-84b1-25caeda906ef'
-        alb.ingress.kubernetes.io/actions.ssl-redirect: >-
-            {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}
-        alb.ingress.kubernetes.io/healthcheck-path: '/actuator/health'
-        alb.ingress.kubernetes.io/healthcheck-port: 'traffic-port'
-        alb.ingress.kubernetes.io/success-codes: '200-399'
+  name: runrun-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: 'alb'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:mx-central-1:118320467932:certificate/38537b2c-f224-4655-882c-65880c767bdb"
+    alb.ingress.kubernetes.io/actions.ssl-redirect: >-
+      {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}
+    alb.ingress.kubernetes.io/healthcheck-path: '/actuator/health'
+    alb.ingress.kubernetes.io/healthcheck-port: 'traffic-port'
+    alb.ingress.kubernetes.io/success-codes: '200-399'
 spec:
-    rules:
-        - host: api.runrunmatch.cloud
-          http:
-              paths:
-                  - path: /
-                    pathType: Prefix
-                    backend:
-                        service:
-                            name: ssl-redirect
-                            port:
-                                name: use-annotation
-                  - path: /
-                    pathType: Prefix
-                    backend:
-                        service:
-                            name: runrun-svc
-                            port:
-                                number: 80
+  rules:
+    - host: api.runrunmatch.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: runrun-svc
+                port:
+                  number: 80


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#161 
## 📝 작업 내용
- 
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 사항 요약

이 PR은 Kubernetes EKS 배포 설정 파일의 ALB(Application Load Balancer) 인증서 ARN을 업데이트합니다.

### 주요 변경 사항
- **파일 수정**: `k8s/eks_deploy_alb.yml`
- **변경 대상**: Ingress 리소스의 `alb.ingress.kubernetes.io/certificate-arn` 어노테이션
- **변경 내용**: AWS ACM 인증서 ARN이 `arn:aws:acm:mx-central-1:118320467932:certificate/38537b2c-f224-4655-882c-65880c767bdb`로 업데이트됨
- **YAML 포맷**: 들여쓰기 및 구조 정렬로 가독성 개선

### 영향 범위
- API 도메인(`api.runrunmatch.cloud`)을 통한 HTTPS 트래픽 처리에 사용되는 SSL/TLS 인증서가 교체됨
- Deployment(2개 replicas), Service(ClusterIP), Ingress(ALB)의 기능적 동작은 변경 없음
- 컨테이너 이미지, 환경 변수, 리소스 제한, 헬스 체크 설정 등 다른 모든 배포 구성은 유지

### 검토 포인트
- 새 인증서 ARN의 유효성 및 만료 기간 확인
- 기존 인증서에서 새 인증서로의 무중단 전환 검증
- 도메인 소유권 및 인증서 정보 일치 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->