### PR TITLE
[feat] 503 서비스 오류 

### DIFF
--- a/k8s/eks_deploy_alb.yml
+++ b/k8s/eks_deploy_alb.yml
@@ -45,11 +45,13 @@ spec:
           # ✅ Health Check 추가
           readinessProbe:
             httpGet:
-              path: /actuator/health/readiness
+              path: /actuator/health
               port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
+            successThreshold: 1
 
           # ✅ Graceful Shutdown 추가
           lifecycle:
@@ -59,10 +61,10 @@ spec:
 
           resources:
             limits:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "250m"
 
       # ✅ 종료 시간 설정


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#203
## 📝 작업 내용
- 503 에러 시 타임 아웃 시간 느림
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경사항 개요

503 서비스 오류 해결을 위해 Kubernetes 배포 설정 파일(`k8s/eks_deploy_alb.yml`)의 타임아웃 및 리소스 관련 설정을 종합적으로 개선하는 변경입니다.

## 주요 변경 사항

### 1. Pod 레벨 헬스체크 설정 강화
- **readinessProbe 추가**
  - Health check 경로: `/actuator/health/readiness` → `/actuator/health` 단순화
  - `initialDelaySeconds`: 10 → **30** (초기 지연 시간 연장)
  - `periodSeconds`: 5 → **10** (주기적 체크 간격 증가)
  - `timeoutSeconds`: **5** (신규 추가)
  - `successThreshold`: **1** (신규 추가)
  - `failureThreshold`: **3** (신규 설정)

### 2. 컨테이너 리소스 할당 증가
- **메모리 Limits**: 512Mi → **1Gi** (2배 증가)
- **메모리 Requests**: 256Mi → **512Mi** (2배 증가)
- CPU 설정: 유지 (Limits 500m, Requests 250m)

### 3. Graceful Shutdown 설정 추가
- `terminationGracePeriodSeconds`: **30**
- `preStop` lifecycle hook: `/bin/sh -c sleep 15` (신규 추가)

### 4. ALB/Load Balancer 레벨 헬스체크 최적화
- ALB healthcheck path: `/actuator/health/liveness` (유지)
- `healthcheck-timeout-seconds`: **5** (신규 추가)
- `healthcheck-interval-seconds`: **15**
- `healthy-threshold-count`: **2**
- `unhealthy-threshold-count`: **2**
- `deregistration_delay.timeout_seconds`: **30** (신규 추가)

## 기술적 평가

### 긍정적 측면
- **계층별 타임아웃 설정 일관성**: Pod 레벨(5초), ALB 레벨(5초), 종료 대기(30초) 설정이 논리적으로 구성됨
- **리소스 여유 확보**: 메모리 2배 증가로 503 에러의 주요 원인 중 하나인 메모리 부족 상황 완화
- **우아한 종료(Graceful Shutdown)**: 기존 요청 처리 중 강제 종료 방지로 에러 감소

### 검토 사항
- Health check 경로 단순화(`/actuator/health`로 변경)가 기존 Spring Boot Actuator 설정과 일치하는지 확인 필요
- 메모리 증가로 인한 클러스터 리소스 전체 영향도 검토 필요 (현재 2개 replica × 2배 메모리)
- 타임아웃 설정이 실제 애플리케이션 응답 시간과 일치하는지 모니터링 필요
- ALB와 Pod 레벨 헬스체크 경로 불일치(`/actuator/health/liveness` vs `/actuator/health`) 확인 필요

## 코드 컨벤션 및 포매팅
- YAML 문법 정확성: ✅ (주석 사용, 들여쓰기 일관성)
- 팀 컨벤션: ✅ (주석 마크(`✅`)로 변경 사항 명확히 표시)
- 포매팅 체크리스트: 미체크 상태 (PR 체크리스트에 미반영)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->