### PR TITLE
[fix] startupProbe 추가하여 유예시간 할애

### DIFF
--- a/k8s/eks_deploy_alb.yml
+++ b/k8s/eks_deploy_alb.yml
@@ -43,11 +43,20 @@ spec:
           imagePullPolicy: Always
 
           # ✅ Health Check 추가 (readiness/liveness 분리)
+          # ✅ Startup Probe 추가 (애플리케이션 시작 시간 동안 liveness가 컨테이너를 죽이지 않도록)
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30 # 최대 5분 (30 * 10초) 동안 유예
+
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120 # 애플리케이션 시작 시간(92초) + 여유 30초
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
@@ -57,7 +66,7 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 60
+            initialDelaySeconds: 150 # readiness보다 여유 있게 설정
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#212 
## 📝 작업 내용
- 
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 사항 분석

이 PR은 Kubernetes 배포 설정(k8s/eks_deploy_alb.yml)에 대한 수정으로, 애플리케이션 시작 시간 동안 헬스체크 실패로 인한 조기 종료를 방지하는 목적입니다.

## 주요 변경 사항

### 1. StartupProbe 추가
- HTTP GET 프로브: `/actuator/health/liveness` 경로, 포트 8080
- 설정값: periodSeconds 10, timeoutSeconds 5, failureThreshold 30
- 최대 약 5분(30 × 10초)의 시작 유예 기간 제공

### 2. ReadinessProbe 개선
- initialDelaySeconds를 30에서 120으로 증대
- 애플리케이션 실측 시작 시간(약 92초) + 여유 30초를 고려한 설정

### 3. LivenessProbe 개선
- initialDelaySeconds를 60에서 150으로 증대
- readinessProbe보다 여유있게 설정하여 준비 완료 후 존속성 검사 시작

### 4. Graceful Shutdown 강화
- lifecycle.preStop 추가: `/bin/sh -c "sleep 15"` 명령 실행
- terminationGracePeriodSeconds: 30 설정
- 쿠버네티스 종료 신호(SIGTERM) 수신 후 15초 대기로 진행 중인 요청 정상 처리 보장

### 5. ALB 헬스체크 최적화
- healthcheck-interval-seconds: 15
- healthy-threshold-count: 2
- unhealthy-threshold-count: 2
- healthcheck-timeout-seconds: 5

## 기술적 검토 포인트

**긍정적 측면:**
- Kubernetes 권장사항에 따른 3단계 헬스체크 분리(startup, readiness, liveness)
- 실측 데이터(92초 시작시간)를 기반한 합리적인 delay 설정
- Graceful shutdown으로 안정적인 배포 롤아웃 지원

**검토 필요 사항:**
- readinessProbe와 livenessProbe의 경로 분리 적절성 검토 필요
  - readiness: `/actuator/health/readiness`
  - liveness: `/actuator/health/liveness`
- 실제 프로덕션 환경에서 5분의 startup 유예 기간이 최적인지 모니터링 필요
- preStop sleep 15초가 실제 request drain 시간과 맞는지 검증 필요

**주의사항:**
- 제공된 지침(API 명세, 인증/인가, 트랜잭션 등)은 백엔드 코드 리뷰 기준이나, 본 PR은 인프라 배포 설정 변경으로 해당 지침과 직접적인 관련이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->