### PR TITLE
[feat] 쿠폰 상태 쿼리 변경

### DIFF
--- a/src/main/java/com/multi/runrunbackend/domain/coupon/respository/CouponIssueRepository.java
+++ b/src/main/java/com/multi/runrunbackend/domain/coupon/respository/CouponIssueRepository.java
@@ -1,6 +1,7 @@
 package com.multi.runrunbackend.domain.coupon.respository;
 
 import com.multi.runrunbackend.domain.coupon.constant.CouponTriggerEvent;
+import com.multi.runrunbackend.domain.coupon.constant.CouponIssueStatus;
 import com.multi.runrunbackend.domain.coupon.entity.Coupon;
 import com.multi.runrunbackend.domain.coupon.entity.CouponIssue;
 import com.multi.runrunbackend.domain.user.entity.User;
@@ -23,6 +24,8 @@ public interface CouponIssueRepository extends JpaRepository<CouponIssue, Long>,
     boolean existsByCouponIdAndUserId(Long couponId, Long userId);
 
     long countByUserId(Long userId);
+
+    long countByUserIdAndStatus(Long userId, CouponIssueStatus status);
 
     Optional<CouponIssue> findByCouponAndUser(Coupon coupon, User user);
 
@@ -172,4 +175,3 @@ public interface CouponIssueRepository extends JpaRepository<CouponIssue, Long>,
         @Param("year") int year
     );
 }
-

--- a/src/main/java/com/multi/runrunbackend/domain/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/multi/runrunbackend/domain/coupon/service/CouponIssueService.java
@@ -59,7 +59,8 @@ public class CouponIssueService {
     @Transactional(readOnly = true)
     public long getCouponCount(CustomUser principal) {
         User user = getUserOrThrow(principal);
-        return couponIssueRepository.countByUserId(user.getId());
+        return couponIssueRepository.countByUserIdAndStatus(user.getId(),
+            CouponIssueStatus.AVAILABLE);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#226 
## 📝 작업 내용
- 
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 쿠폰 상태 필터링을 통한 사용 가능 쿠폰 조회 기능 개선

### 변경 사항

**CouponIssueRepository**
- 새로운 쿼리 메서드 추가: `long countByUserIdAndStatus(Long userId, CouponIssueStatus status)`
- JpaRepository 쿼리 메서드 네이밍 규칙 준수하여 특정 상태의 쿠폰만 집계 가능하도록 개선

**CouponIssueService**
- `getCouponCount()` 메서드 로직 변경: `countByUserId()` → `countByUserIdAndStatus(userId, CouponIssueStatus.AVAILABLE)`
- 사용자가 보유한 모든 쿠폰을 세는 것이 아닌, **AVAILABLE 상태의 쿠폰만 집계하도록 변경**
- 트랜잭션 설정 유지 (readOnly = true)

### 기능 변경점

- **기존**: 사용자가 발급받은 모든 쿠폰의 총 개수 반환
- **변경**: 사용자가 실제로 사용 가능한 쿠폰(AVAILABLE 상태)의 개수만 반환
- 이로 인해 이미 사용된(USED), 만료된(EXPIRED), 삭제된(DELETED) 쿠폰은 카운트에서 제외됨

### 코드 컨벤션 준수 사항

- ✅ 팀의 JpaRepository 쿼리 메서드 네이밍 규칙 준수 (`countByUserIdAndStatus`)
- ✅ 서비스 계층의 사용자 검증 로직 유지 (`getUserOrThrow`)
- ✅ 읽기 전용 트랜잭션 적용 (`@Transactional(readOnly = true)`)
- ✅ 상태 기반 필터링으로 일관된 쿠폰 상태 관리

### 영향 범위

- **직접 영향**: CouponIssueController의 `getCouponCount` API 응답값 변경
- **제한된 범위**: 해당 메서드는 특정 엔드포인트에서만 호출되므로 영향 범위 최소화
- **선택적 마이그레이션**: AVAILABLE 상태 필터링으로 인해 클라이언트 로직 재검토 필요 가능

### 추가 개선 사항

- 파일 끝에 줄바꿈 추가로 코드 포맷팅 규칙 준수

<!-- end of auto-generated comment: release notes by coderabbit.ai -->