### PR TITLE
[feat] 쿠폰 @sqlrestriction 제거

### DIFF
--- a/src/main/java/com/multi/runrunbackend/domain/coupon/entity/CouponIssue.java
+++ b/src/main/java/com/multi/runrunbackend/domain/coupon/entity/CouponIssue.java
@@ -8,7 +8,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
@@ -29,7 +28,6 @@ import java.time.LocalDateTime;
                         "user_id"})
         }
 )
-@SQLRestriction("status = 'AVAILABLE'")
 public class CouponIssue extends BaseCreatedEntity {
 
     @Id


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#229 
## 📝 작업 내용
- 
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 쿠폰 @SQLRestriction 제거

### 주요 변경사항

**수정 파일**: `src/main/java/com/multi/runrunbackend/domain/coupon/entity/CouponIssue.java`

- Hibernate의 `@SQLRestriction("status = 'AVAILABLE'")` 어노테이션 제거
- 변경 라인: +0/-2 (순수 어노테이션 삭제)

### 기능 영향 범위

#### 변경 전동작
- CouponIssue 엔티티에 @SQLRestriction이 적용되어, 모든 쿼리에서 자동으로 `status = 'AVAILABLE'` 조건이 런타임에 추가됨
- 개발자가 의도하지 않았더라도 AVAILABLE 상태의 쿠폰만 조회되도록 강제함

#### 변경 후동작  
- 엔티티 레벨에서의 자동 필터링이 제거되어, 명시적인 상태 필터링 필요
- 모든 쿠폰 발급 상태(AVAILABLE, USED, DELETED, EXPIRED 등)에 대한 쿼리 결과 노출 가능

### 코드 컨벤션 준수 여부

#### 검토 결과
- **상태 필터링**: 서비스 레이어(CouponIssueService)에서 `CouponIssueStatus.AVAILABLE`을 명시적으로 사용하고 있음 (예: `countByUserIdAndStatus()`, `deleteC ouponIssue()`)
- **쿼리 필터링**: 커스텀 리포지토리(CouponIssueRepositoryImpl)에서 네이티브 쿼리로 `WHERE ci.status = 'AVAILABLE'` 조건을 수동 작성
- **Optional 사용**: `findById().orElseThrow()` 패턴으로 일관되게 처리

#### 주의사항
- CouponIssueRepository의 JPA 메서드 쿼리(예: `findByCouponAndUser()`)에서는 @SQLRestriction이 더 이상 자동으로 적용되지 않으므로, 의도하지 않은 DELETED/EXPIRED 상태 쿠폰까지 조회될 가능성 존재
- 리포지토리에 주석으로 "`@SQLRestriction 때문에 native query 사용`"이라고 표기된 부분이 있어, 이 제거의 의도가 쿼리 유연성 확보임을 시사

### 권고사항
1. 모든 CouponIssue 조회 메서드에서 상태 필터링이 명시적으로 이루어지는지 재검토 필요
2. AVAILABLE 상태만 필요한 경우와 모든 상태가 필요한 경우를 구분하여 메서드명 명확히 할 것
3. 기존 @SQLRestriction 의존 코드가 있다면 상태 필터 추가 필요

<!-- end of auto-generated comment: release notes by coderabbit.ai -->