### PR TITLE
[design] 관리자 서치 바 제거

### DIFF
--- a/src/main/resources/templates/admin/layout.html
+++ b/src/main/resources/templates/admin/layout.html
@@ -1,21 +1,19 @@
 <!doctype html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <body>
-  <div class="admin-layout" th:fragment="adminLayout(content)">
-    <!-- 왼쪽 사이드바 -->
-    <div th:replace="~{common/sidebar :: sidebar}"></div>
-    
-    <!-- 메인 컨텐츠 영역 -->
-    <main class="main-content">
-      <!-- 상단 검색창 -->
-      <div th:replace="~{common/search-bar :: searchBar}"></div>
-      
-      <!-- 페이지 컨텐츠 -->
-      <div class="content-wrapper">
-        <th:block th:insert="${content}"></th:block>
-      </div>
-    </main>
-  </div>
+<div class="admin-layout" th:fragment="adminLayout(content)">
+  <!-- 왼쪽 사이드바 -->
+  <div th:replace="~{common/sidebar :: sidebar}"></div>
+
+  <!-- 메인 컨텐츠 영역 -->
+  <main class="main-content">
+
+    <!-- 페이지 컨텐츠 -->
+    <div class="content-wrapper">
+      <th:block th:insert="${content}"></th:block>
+    </div>
+  </main>
+</div>
 </body>
 </html>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#235 
## 📝 작업 내용
- 관리자 서치 바 제거
- 포인트 +1p ui 제거
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR 요약

### 변경 내용
이 PR은 관리자 페이지의 UI/UX 개선을 위한 두 가지 주요 변경사항을 포함합니다:

#### 1. 관리자 레이아웃에서 서치 바 제거
- **파일**: `src/main/resources/templates/admin/layout.html`
- **변경 사항**: 메인 컨텐츠 영역의 상단 서치 바 컴포넌트 제거
- **영향**: 관리자 페이지 레이아웃이 더 간결해짐
- **기능적 변화**: 없음 (UI 제거만 해당)

#### 2. 포인트 시스템에서 "+1P" 추가 보너스 제거
- **파일**: `src/main/java/com/multi/runrunbackend/domain/point/service/PointService.java`
- **변경 사항**:
  - `earnPointsForRunningComplete()` 메서드: 프리미엄 멤버십 사용자에 대한 "+1P" 추가 보너스 제거
  - 기존: 100m당 1P + 프리미엄 사용자는 추가 1P (총 2배)
  - 변경 후: 100m당 1P 기본 계산만 유지
  - 메서드 주석 및 로직 정리
- **영향**: 포인트 적립 정책 변경으로 프리미엄 회원의 추가 포인트 보너스 제거

### 코드 품질 검토 사항
- 서비스 레이어 변경은 포인트 적립 비즈니스 로직에만 영향을 미침
- DTO 및 엔티티는 변경 없음으로 API 호환성 유지
- 트랜잭션 처리 및 예외 처리는 기존과 동일하게 유지
- 포인트 정책 변경이 명확하게 반영됨

### 주의사항
- 프리미엄 멤버십 사용자의 포인트 적립 정책 변경으로 인한 비즈니스 임팩트 확인 필요
- 기존 데이터에 영향을 주지는 않으나, 향후 포인트 적립은 새로운 정책이 적용됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->