### PR TITLE
[feat] 웹소켓 테스트 환경 분리

### DIFF
--- a/src/main/java/com/multi/runrunbackend/common/config/WebSocketConfig.java
+++ b/src/main/java/com/multi/runrunbackend/common/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.multi.runrunbackend.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -16,16 +17,25 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-  @Override
-  public void configureMessageBroker(MessageBrokerRegistry registry) {
-    registry.enableSimpleBroker("/sub");  // 구독 경로
-    registry.setApplicationDestinationPrefixes("/pub");  // 발행 경로
-  }
+    @Value("${WS_TEST_ENABLED:false}")
+    private boolean wsTestEnabled;
 
-  @Override
-  public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry.addEndpoint("/ws")  // WebSocket 연결 엔드포인트
-        .setAllowedOriginPatterns("*")
-        .withSockJS();
-  }
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");  // 구독 경로
+        registry.setApplicationDestinationPrefixes("/pub");  // 발행 경로
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")  // WebSocket 연결 엔드포인트
+            .setAllowedOriginPatterns("*")
+            .withSockJS();
+        if (wsTestEnabled) {
+            registry.addEndpoint("/ws-test")
+                .setAllowedOriginPatterns("*");
+        }
+    }
+
+
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,38 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD:}
+      ssl:
+        enabled: ${REDIS_SSL_ENABLED:false}
+      database: 0
+      timeout: 2000ms
+  mongodb:
+    # External MongoDB (e.g., MongoDB Atlas) endpoint injected via Secret(runrun-env)
+    uri: ${MONGO_URI}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+
+server:
+  tomcat:
+    keep-alive-timeout: 65s


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#239 
## 📝 작업 내용
- 웹소켓 테스트 추가
- 젠킨스 테스트 토글 추가

## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## WebSocket 테스트 환경 분리 및 부하 테스트 지원

### 개요
이 PR은 WebSocket 기능을 프로덕션 환경과 테스트 환경으로 분리하여, 부하 테스트용 순수 WebSocket 엔드포인트를 Jenkins 파라미터로 제어할 수 있는 기능을 추가합니다.

### 주요 변경사항

#### 1. WebSocketConfig.java - 조건부 엔드포인트 등록
- **@Value 주입**: `${WS_TEST_ENABLED:false}` 환경변수로 테스트 엔드포인트 토글 구현
- **기존 엔드포인트 보존**: `/ws` 엔드포인트는 SockJS 활성화 상태로 유지 (기존 클라이언트 호환성 보장)
- **새로운 테스트 엔드포인트**: `wsTestEnabled=true`일 때만 `/ws-test` 엔드포인트 등록
  - SockJS 미적용으로 순수 WebSocket 방식 제공
  - 부하 테스트에 최적화된 경량 구성
- **코드 컨벤션**: 기타 Configuration 클래스의 @Value 사용 패턴과 일치 (기본값 설정, camelCase 필드명)

#### 2. Jenkinsfile - 배포 파이프라인 개선
- **새로운 빌드 파라미터**: `WS_TEST_ENABLED` (booleanParam, 기본값: false)
  - 설명: "Enable /ws-test pure WebSocket endpoint for load testing (prod-safe toggle)."
  - Jenkins UI에서 빌드 시 선택 가능
- **Kubernetes Secret 관리**: 
  - Jenkins 파라미터를 base64 인코딩하여 `runrun-env` Secret에 저장
  - 기존 MONGO_URI 처리 로직과 분리하여 안정성 강화
  - Secret 미존재 시 자동 생성, 존재 시 Merge 방식으로 기존 값 보존
- **배포 안정성**: 파라미터는 기본값 false로 설정되어 명시적 활성화 시에만 테스트 엔드포인트 노출

#### 3. application-test.yml - 테스트 프로필 설정 추가
- **PostgreSQL DataSource**: 테스트용 데이터소스 설정 (환경변수 기반)
- **Redis 및 MongoDB**: 외부 데이터 저장소 연결 설정
- **Management 엔드포인트**: health, info, prometheus 메트릭 노출
- **Kubernetes Probe**: livenessProbe, readinessProbe 활성화
- **Tomcat 설정**: Keep-alive 타임아웃 65초 설정

### 기술적 고려사항

#### 보안성
- 프로덕션 환경에서 기본적으로 테스트 엔드포인트 비활성화 (안전한 기본값)
- Jenkins 파라미터를 통한 명시적 제어로 의도하지 않은 활성화 방지
- Kubernetes Secret 기반 환경변수 주입으로 보안 강화

#### 하위 호환성
- 기존 `/ws` 엔드포인트 SockJS 구성 완전 보존
- 기존 클라이언트는 변경 없이 정상 동작
- 테스트 엔드포인트는 신규 추가로 기존 기능 영향 없음

#### 운영 편의성
- application-test.yml 추가로 프로파일 기반 환경 관리 용이
- Jenkins 빌드 시 UI 체크박스로 간편 제어
- MONGO_URI와 분리된 별도 처리로 각 설정의 독립성 보장

### 예상 활용 사례
1. 부하 테스트 시: Jenkins 빌드 파라미터에서 `WS_TEST_ENABLED=true` 선택
2. 테스트 환경: application-test.yml 프로파일 활성화로 테스트 DB 연결
3. 프로덕션: 기본값 유지로 테스트 엔드포인트 자동 비활성화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->